### PR TITLE
Add prebuilt kernel config

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -36,6 +36,7 @@ BOARD_MKBOOTIMG_ARGS := --ramdisk_offset 0x01600000
 # Kernel
 TARGET_KERNEL_SOURCE := kernel/lge/mako
 TARGET_KERNEL_CONFIG := mako_defconfig
+TARGET_PREBUILT_KERNEL := device/lge/mako-kernel/kernel
 
 BOARD_USES_ALSA_AUDIO:= true
 BOARD_USES_LEGACY_ALSA_AUDIO:= false


### PR DESCRIPTION
This gets rid of the current error when building mako. Will revert once the CM kernel source becomes available.

Change-Id: Idc182e44f945a42a3359f78aacb078aec3b5c834
